### PR TITLE
feat: Remove hardcoded speech error corrections

### DIFF
--- a/mtt/__init__.py
+++ b/mtt/__init__.py
@@ -5,7 +5,7 @@ YouTube 영상에서 자막을 추출하고 보정하는 패키지
 
 from .downloader import download_youtube_audio
 from .transcriber import transcribe_audio
-from .corrector import correct_transcription_text, fix_common_speech_errors, fix_ai_based_corrections
+from .corrector import correct_transcription_text, fix_ai_based_corrections
 from .utils import create_output_directory, save_subtitle_and_metadata
 from .main_processor import youtube_to_subtitle
 
@@ -14,7 +14,6 @@ __all__ = [
     'download_youtube_audio',
     'transcribe_audio', 
     'correct_transcription_text',
-    'fix_common_speech_errors',
     'fix_ai_based_corrections',
     'create_output_directory',
     'save_subtitle_and_metadata',


### PR DESCRIPTION
- Remove fix_common_speech_errors() function and hardcoded Korean error patterns
- Simplify correct_transcription_text() to rely solely on AI-based corrections
- Update __init__.py exports to remove fix_common_speech_errors
- Improve universality by removing language-specific and domain-specific logic
- Reduce maintenance overhead and code complexity
- Better accuracy through AI-only approach

Fixes #4